### PR TITLE
Removed error-prone ordering of 2x2 table.

### DIFF
--- a/test_comparison.R
+++ b/test_comparison.R
@@ -4,9 +4,7 @@ comparison <- function(x,y){
   x <- if_else(x == '2','0','1')
   y <- if_else(y == '2','0','1')
   levs <- sort(union(x, y))
-  tab <- table(factor(x,levs),factor(y,levs))
-  tab2<-tab[order(tab[,2],decreasing=T),
-            order(tab[2,],decreasing=T)]
+  tab2 <-table(factor(x, levels=c('1','0')), factor(y, levels = c('1', '0')))
   McN <- stats::mcnemar.test(tab2[])
   {total <- (tab2[1]+tab2[2]+tab2[3]+tab2[4])
     sp <- (tab2[4]/(tab2[4]+tab2[2]))


### PR DESCRIPTION
The previous version didn't always order the 2x2 table correctly, meaning positive ('1') were not always ordered in the appropriate position of the table, namely the first of two rows and the first of two columns. This patch resolves that issue.